### PR TITLE
chore: style unkown_project for consistency

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -290,7 +290,7 @@ export function calculateEvaluationStats(evaluations: Evaluation[]): EvaluationS
       projectName = gitlabPath.split('/').slice(-2).join('/');
     } else {
       const projectEntry = projectMap.find(p => p.id === evaluation.team.project_id);
-      projectName = projectEntry ? projectEntry.project_path : 'Unknown Project';
+      projectName = projectEntry ? projectEntry.project_path : 'unkown_project';
     }
 
     if (!stats.projectStats[projectName]) {


### PR DESCRIPTION
- Updated the fallback value for project names in the `calculateEvaluationStats` function from 'Unknown Project' to 'unkown_project' to ensure consistency in project name handling.