### PR TITLE
refactor: remove outdated content from About, Privacy, and Terms pages

### DIFF
--- a/app/(main)/about/page.tsx
+++ b/app/(main)/about/page.tsx
@@ -59,59 +59,6 @@ export default function About() {
 
         <Card>
           <CardHeader>
-            <CardTitle className="font-mono" id="features">
-              Key Features
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div>
-              <h3 className="mb-4 font-mono text-sm">🔐 Secure Authentication</h3>
-              <p>
-                Secure OAuth 2.0 integration with the 42 API, featuring JWT token management, middleware-based route protection, and secure cookie handling with httpOnly and sameSite policies.
-              </p>
-            </div>
-
-            <div>
-              <h3 className="mb-4 font-mono text-sm">📊 Comprehensive Evaluation Analytics</h3>
-              <p>
-                Advanced evaluation statistics including peer evaluation performance metrics, interactive quality metrics with feedback length distribution analysis, project-specific performance tracking, and flag distribution visualization (Ok, Outstanding, Failed).
-              </p>
-            </div>
-
-            <div>
-              <h3 className="mb-4 font-mono text-sm">🎓 Academic Performance Tracking</h3>
-              <p>
-                Detailed C Piscine exam analysis with comprehensive scoring breakdowns, performance evolution tracking with trend analysis, success rate calculations, and predictive insights for academic progression.
-              </p>
-            </div>
-
-            <div>
-              <h3 className="mb-4 font-mono text-sm">🎵 Hall Voice Integration</h3>
-              <p>
-                Seamless integration with the{" "}
-                <Link
-                  className="text-foreground hover:underline font-mono"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="https://github.com/42paris/hall-voice"
-                >
-                  hall-voice repository
-                </Link>
-                , featuring custom audio playback interface, sound categorization (in/out sounds), and GitHub API integration for seamless file access.
-              </p>
-            </div>
-
-            <div>
-              <h3 className="mb-4 font-mono text-sm">📱 Modern User Experience</h3>
-              <p>
-                Progressive Web App (PWA) capabilities, responsive design with Tailwind CSS, dark/light theme support, real-time data visualization with Chart.js and Recharts, and comprehensive error handling with Discord webhook integration for production monitoring.
-              </p>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
             <CardTitle className="font-mono" id="how-it-works">
               How it Works
             </CardTitle>

--- a/app/(main)/privacy/page.tsx
+++ b/app/(main)/privacy/page.tsx
@@ -103,7 +103,6 @@ export default function Privacy() {
             <ul className="list-disc list-inside mt-2 space-y-1">
               <li><strong>42 API:</strong> Official 42 API for student data, evaluations, and academic records</li>
               <li><strong>GitHub API:</strong> For accessing hall voice sound files from the 42paris/hall-voice repository</li>
-              <li><strong>Discord Webhooks:</strong> For error monitoring and system alerts (production only)</li>
             </ul>
             <p className="mt-4">
               <strong>No Analytics or Tracking:</strong> We do not use any third-party analytics, tracking, or advertising services. Your data is never shared with any third parties for marketing or commercial purposes.
@@ -127,27 +126,6 @@ export default function Privacy() {
               <li><strong>Rate Limiting:</strong> API rate limiting to prevent abuse and ensure service stability</li>
               <li><strong>Error Monitoring:</strong> Secure error reporting without exposing sensitive data</li>
             </ul>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="font-mono">Your Privacy Rights</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="mb-4">
-              You have full control over your data and privacy:
-            </p>
-            <ul className="list-disc list-inside mt-2 space-y-1">
-              <li><strong>Right to Access:</strong> You can view all data we have about you (stored in your browser)</li>
-              <li><strong>Right to Deletion:</strong> Sign out at any time to immediately clear all session data</li>
-              <li><strong>Right to Portability:</strong> All data is accessible through your browser&apos;s developer tools</li>
-              <li><strong>Right to Revoke Access:</strong> Revoke ft_portal&apos;s access through your 42 OAuth applications settings</li>
-              <li><strong>Right to Object:</strong> You can stop using the service at any time</li>
-            </ul>
-            <p className="mt-4">
-              Since we don&apos;t store your data on our servers, most privacy rights are automatically satisfied. Your data remains under your control at all times.
-            </p>
           </CardContent>
         </Card>
 
@@ -194,7 +172,7 @@ export default function Privacy() {
               >
                 GitHub repository
               </Link>
-              {" "}or by creating an issue in the repository.
+              {" "}by creating an issue in the repository.
             </p>
           </CardContent>
         </Card>

--- a/app/(main)/terms/page.tsx
+++ b/app/(main)/terms/page.tsx
@@ -63,17 +63,6 @@ export default function Terms() {
 
         <Card>
           <CardHeader>
-            <CardTitle className="font-mono">Service Description</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p>
-              ft_portal is a comprehensive analytics platform that provides visualization and analysis of student data from the 42 API. The service includes evaluation analytics, academic performance tracking, hall voice integration, and data visualization tools designed for the 42 community.
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
             <CardTitle className="font-mono">Acceptable Use</CardTitle>
           </CardHeader>
           <CardContent>
@@ -89,27 +78,6 @@ export default function Terms() {
               <li>Not interfere with or disrupt the service or servers</li>
               <li>Not attempt to gain unauthorized access to any part of the service</li>
             </ul>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="font-mono">API Usage & Rate Limiting</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="mb-4">
-              ft_portal integrates with the 42 API and GitHub API. You agree to:
-            </p>
-            <ul className="list-disc list-inside mt-2 space-y-1">
-              <li>Respect the rate limits and usage policies of both the 42 API and GitHub API</li>
-              <li>Not abuse or overload the APIs through excessive requests</li>
-              <li>Not attempt to scrape or collect data in bulk without authorization</li>
-              <li>Use the APIs in accordance with their respective terms of service</li>
-              <li>Accept that API availability and response times may vary</li>
-            </ul>
-            <p className="mt-4">
-              We implement rate limiting and request throttling to ensure fair usage and service stability for all users.
-            </p>
           </CardContent>
         </Card>
 
@@ -157,61 +125,6 @@ export default function Terms() {
 
         <Card>
           <CardHeader>
-            <CardTitle className="font-mono">Intellectual Property</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p>
-              ft_portal and its original content, features, and functionality are owned by the ft_portal team and are protected by international copyright, trademark, patent, trade secret, and other intellectual property laws. The service is provided as-is without any warranties regarding ownership or rights to the underlying data, which remains the property of 42 and respective data owners.
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="font-mono">Service Availability</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p>
-              ft_portal is provided on an &quot;as is&quot; and &quot;as available&quot; basis. We do not guarantee uninterrupted or error-free service. The service may be temporarily unavailable due to maintenance, updates, or technical issues. We reserve the right to modify, suspend, or discontinue the service at any time with or without notice.
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="font-mono">Limitation of Liability</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p>
-              In no event shall ft_portal, its developers, or contributors be liable for any indirect, incidental, special, consequential, or punitive damages, including without limitation, loss of profits, data, use, goodwill, or other intangible losses, resulting from your use of the service. We are not responsible for any misuse of the service, changes to the 42 API that may affect functionality, or any consequences of using the service.
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="font-mono">Indemnification</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="">
-              You agree to defend, indemnify, and hold harmless ft_portal, its developers, and contributors from and against any claims, damages, obligations, losses, liabilities, costs, or debt arising from your use of the service or violation of these terms.
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="font-mono">Governing Law</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="">
-              These terms shall be governed by and construed in accordance with the laws of the jurisdiction where the service is hosted, without regard to its conflict of law provisions. Any disputes arising from these terms or your use of the service shall be resolved through appropriate legal channels.
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
             <CardTitle className="font-mono">Changes to Terms</CardTitle>
           </CardHeader>
           <CardContent>
@@ -236,7 +149,7 @@ export default function Terms() {
               >
                 GitHub repository
               </Link>
-              {" "}or by creating an issue in the repository.
+              {" "}by creating an issue in the repository.
             </p>
           </CardContent>
         </Card>


### PR DESCRIPTION
- Eliminate key features section from About page for a more concise overview
- Remove privacy rights details from Privacy page to streamline content
- Delete service description and related sections from Terms page for clarity
- Update related links and text for improved consistency across pages